### PR TITLE
docs: add DevOps governance and roadmap

### DIFF
--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -89,3 +89,25 @@ Any change with visual impact must follow frontend UI/UX best practices and adhe
 - Use the `frontend-design` skill when building new UI components
 - Visual changes without a style guide reference or design review are not considered complete
 - "It compiles and the tests pass" is not sufficient for frontend work — visual correctness must be verified
+
+## Article 11: Mise + Dagger CI/CD
+
+All CI/CD pipeline logic must live in Dagger pipelines, invoked through Mise tasks. External CI systems (GitHub Actions, etc.) serve only as triggers.
+
+- **Mise** is the developer-facing entry point for all project commands (`mise run ci`, `mise run dev`, `mise run deploy:staging`)
+- **Mise** manages tool versions (Java, Node, Maven, Dagger) and environment variables via `.mise.toml` — no system-level dependencies required beyond Mise itself
+- **Dagger** implements containerized pipeline steps (build, test, scan, image build, deploy) as functions
+- **Podman** is the container runtime — no Docker dependency. Rootless by default.
+- CI system workflows must be thin wrappers: checkout → install Mise → `mise run ci`
+- No build logic, test orchestration, or deployment steps in CI system YAML/config
+- Pipelines must produce identical results locally and in CI
+- This ensures CI/CD is portable, testable, and not locked to any single CI platform or container runtime
+
+## Article 12: Infrastructure as Code
+
+All cloud infrastructure must be defined in code using OpenTofu. No manual resource creation via console or CLI.
+
+- Infrastructure changes follow the same review process as application code (PR-based)
+- State must be stored remotely with locking (S3 + DynamoDB)
+- Environments are parameterized via variable files, not duplicated modules
+- Secrets and credentials must never appear in IaC files — use AWS Secrets Manager or SSM Parameter Store

--- a/docs/specs/DEVOPS_ROADMAP.md
+++ b/docs/specs/DEVOPS_ROADMAP.md
@@ -1,0 +1,107 @@
+# DevOps Capabilities Roadmap
+
+> Roadmap for infrastructure, CI/CD, monitoring, security, and developer experience improvements.
+> Each spec follows the SDD workflow: SDD-1 → SDD-2 → analyze → SDD-3 → SDD-4.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Cloud provider | AWS | Admin access available, portfolio target |
+| Container runtime | Podman | FOSS (Apache 2.0), rootless, native Linux, no Docker licensing |
+| IaC tool | OpenTofu | FOSS (MPL 2.0), native state encryption, drop-in Terraform replacement |
+| CI/CD engine | Dagger | Containerized pipelines, identical local and CI execution |
+| Task runner / tool mgmt | Mise | Tool versions, env vars, task runner in one `.mise.toml` |
+| CI trigger | GitHub Actions | Thin wrapper only — `mise run ci`, no logic in YAML |
+| Orchestration | ECS Fargate | No Kubernetes — simple, serverless containers |
+| Database (cloud) | RDS PostgreSQL | Managed, "the right way" for a real app |
+| Metrics | Amazon Managed Prometheus (AMP) | Cloud-native, foundation for capstone |
+| Dashboards | Amazon Managed Grafana (AMG) | Cloud-native, pairs with AMP |
+| Logs | CloudWatch Logs | Native AWS, simple |
+| Anomaly detection | CloudWatch Anomaly Detection | Per-metric ML, built-in |
+| Vulnerability scanning | Grype (CI) + AWS Inspector (ECR) | Grype for SBOM in pipeline, Inspector for images |
+| Environments | Staging + Prod | Dev is local only |
+| Alerts | Not in scope | Learning exercise — skip for simplicity |
+
+## Constitution Amendments
+
+- **Article 11: Mise + Dagger CI/CD** — All pipeline logic in Dagger, invoked via Mise tasks. GHA is a thin trigger. Podman as container runtime.
+- **Article 12: Infrastructure as Code** — All infra in OpenTofu. Remote state with locking. No manual console changes. No secrets in code.
+
+## Spec Execution Order
+
+### Spec 11: Production Containerization
+
+- **Status:** Not started
+- **Directory:** `docs/specs/11-spec-production-containerization/`
+- **Scope:** Multi-stage Containerfile (Podman-compatible), optimized Spring Boot image, GHCR/ECR-ready
+- **Depends on:** Nothing
+
+### Spec 12: Dagger CI Pipeline + Mise Setup
+
+- **Status:** Not started
+- **Directory:** `docs/specs/12-spec-dagger-ci-pipeline/`
+- **Scope:** `.mise.toml` (tool versions, tasks), Dagger pipeline (build → test → coverage gate → image build/push to ECR), thin GHA trigger workflow
+- **Depends on:** Spec 11
+
+### Spec 13: OpenTofu Foundation
+
+- **Status:** Not started
+- **Directory:** `docs/specs/13-spec-opentofu-foundation/`
+- **Scope:** VPC, ECR, ECS Fargate, RDS PostgreSQL, IAM, security groups — staging + prod environments. S3 + DynamoDB state backend. Single module with tfvars per environment.
+- **Depends on:** Spec 11
+
+### Spec 14: CD Pipeline (Deploy)
+
+- **Status:** Not started
+- **Directory:** `docs/specs/14-spec-cd-pipeline/`
+- **Scope:** Dagger deploy functions (push to ECR → update ECS Fargate service). Staging deploy on merge to main. Prod deploy on git tag. Manual approval gate for prod.
+- **Depends on:** Specs 12, 13
+
+### Spec 15: Monitoring & Observability
+
+- **Status:** Not started
+- **Directory:** `docs/specs/15-spec-monitoring-observability/`
+- **Scope:** Micrometer integration in Spring Boot → AMP. AMG dashboards (latency, error rate, throughput, JVM metrics). CloudWatch Logs aggregation. CloudWatch Anomaly Detection on key metrics. OpenTofu for AMP/AMG/CloudWatch resources.
+- **Depends on:** Specs 13, 14
+
+### Spec 16: Security Scanning
+
+- **Status:** Not started
+- **Directory:** `docs/specs/16-spec-security-scanning/`
+- **Scope:** Grype integration in Dagger pipeline (scan CycloneDX SBOM). AWS Inspector enabled on ECR repos. Fail pipeline on critical/high vulnerabilities.
+- **Depends on:** Spec 12
+
+### Spec 17: Dev Environment & Lean Tooling
+
+- **Status:** Not started
+- **Directory:** `docs/specs/17-spec-dev-environment/`
+- **Scope:** One-command `mise run dev` setup (install tools, start Podman Compose postgres, run Spring Boot). Pre-commit hook auto-install. Developer onboarding documentation. Remove Tilt dependency.
+- **Depends on:** Spec 12
+
+### Capstone: AI-Powered Platform Engineering Tool
+
+- **Status:** Not started
+- **Directory:** `docs/specs/20-spec-ai-platform-tool/`
+- **Scope:** Separate internal-only interface (not the user-facing pet clinic assistant). Queries AMP/AMG/CloudWatch. AI-driven operational insights. Distinct security boundary from the application.
+- **Depends on:** Spec 15
+
+## Dependency Graph
+
+```text
+Spec 11 (Containerization)
+  ├── Spec 12 (Dagger CI + Mise)
+  │     ├── Spec 14 (CD Pipeline) ← also needs Spec 13
+  │     ├── Spec 16 (Security Scanning)
+  │     └── Spec 17 (Dev Environment)
+  └── Spec 13 (OpenTofu Foundation)
+        ├── Spec 14 (CD Pipeline) ← also needs Spec 12
+        └── Spec 15 (Monitoring) ← also needs Spec 14
+              └── Capstone (AI Platform Tool)
+```
+
+## Execution Sequence
+
+1. Spec 11 → 2. Spec 12 → 3. Spec 13 → 4. Spec 14 → 5. Spec 15 → 6. Spec 16 → 7. Spec 17 → 8. Capstone
+
+Specs 16 and 17 can run in parallel after Spec 12 if desired.


### PR DESCRIPTION
## Summary
- Constitution Article 11: Mise + Dagger CI/CD governance
- Constitution Article 12: Infrastructure as Code governance (OpenTofu)
- DevOps roadmap with 7 specs + capstone, tool decisions, dependency graph

## Test plan
- [x] Documentation only — no code changes
- [x] Markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added governance policies establishing CI/CD pipeline and infrastructure management standards to project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->