### PR TITLE
chore(infra): AWS bootstrap docs and mise CLI setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ temp
 .local/
 **/.terraform/
 **/.terraform.lock.hcl
+# OpenTofu local state (bootstrap)
+**/terraform.tfstate
+**/terraform.tfstate.backup

--- a/.mise.toml
+++ b/.mise.toml
@@ -4,6 +4,7 @@ node = "20"
 maven = "3.9"
 dagger = "latest"
 opentofu = "latest"
+aws = "latest"
 
 [tasks.ci]
 description = "Run full CI pipeline (build, test, coverage, image build)"

--- a/README.md
+++ b/README.md
@@ -16,8 +16,23 @@ The Emerald Grove Veterinary Clinic application manages the core operations of a
 
 ### Prerequisites
 
-- **[Mise](https://mise.jdx.dev/)** — tool version manager (installs Java, Node, Maven, Dagger automatically)
+- **[Mise](https://mise.jdx.dev/)** — tool version manager (installs Java, Node, Maven, Dagger, AWS CLI automatically)
 - **[Podman](https://podman.io/)** — container runtime (used for CI pipeline and local dev)
+
+After installing Mise, activate it in your shell (one-time setup):
+
+```bash
+# Fish
+echo 'mise activate fish | source' >> ~/.config/fish/config.fish
+
+# Bash
+echo 'eval "$(mise activate bash)"' >> ~/.bashrc
+
+# Zsh
+echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+```
+
+Then restart your shell or source the config file.
 
 ### Setup
 
@@ -26,7 +41,7 @@ The Emerald Grove Veterinary Clinic application manages the core operations of a
 git clone https://github.com/liatrio-forge/emerald-grove-pet-clinic-matt-rucker.git
 cd emerald-grove-pet-clinic-matt-rucker
 
-# Install all required tools (Java 17, Node 20, Maven, Dagger)
+# Install all required tools (Java 17, Node 20, Maven, Dagger, AWS CLI, OpenTofu)
 mise install
 
 # Trust the project config (first time only)
@@ -116,7 +131,7 @@ Developer (local)          GitHub Actions (CI)
                     │
             ┌───────┴────────┐
             │  Dagger Engine │
-            │  (containerized)│
+            │ (containerized)│
             └───────┬────────┘
                     │
         ┌───────────┼───────────┐
@@ -131,6 +146,8 @@ Developer (local)          GitHub Actions (CI)
 - **[Architecture Guide](docs/ARCHITECTURE.md)** - System design and technical decisions
 - **[Testing Guide](docs/TESTING.md)** - Comprehensive testing strategies and patterns
 - **[E2E Tests (Playwright)](docs/TESTING.md#end-to-end-e2e-browser-tests-playwright)** - How to run browser-based end-to-end tests
+- **[AWS Bootstrap Guide](docs/BOOTSTRAP.md)** - One-time AWS state backend setup
+- **[Infrastructure Guide](infra/README.md)** - OpenTofu modules, environments, and deployment
 
 ## Development Standards
 

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -1,0 +1,144 @@
+# AWS Bootstrap Guide
+
+This guide walks through the one-time setup required to provision the AWS state backend and prepare the account for infrastructure management with OpenTofu.
+
+## Prerequisites
+
+1. **Mise installed and activated** — see [README Quick Start](../README.md#quick-start)
+2. **AWS account** with admin access
+3. **IAM user created** with programmatic access (Access Key ID + Secret Access Key)
+4. **AWS CLI configured** with credentials:
+
+```bash
+aws configure
+# AWS Access Key ID: <your-key-id>
+# AWS Secret Access Key: <your-secret-key>
+# Default region: us-east-1
+# Default output: json
+```
+
+Verify credentials work:
+
+```bash
+aws sts get-caller-identity
+```
+
+## What Gets Created
+
+The bootstrap process creates two AWS resources that OpenTofu uses to safely store and lock infrastructure state:
+
+| Resource | Name | Purpose |
+|---|---|---|
+| S3 Bucket | `emerald-grove-tfstate` | Stores OpenTofu state files (versioned, encrypted, private) |
+| DynamoDB Table | `emerald-grove-tflock` | Prevents concurrent state modifications (distributed locking) |
+
+These resources are managed separately from the main infrastructure because they must exist before OpenTofu can use remote state.
+
+## Bootstrap Steps
+
+### Step 1: Initialize
+
+```bash
+tofu -chdir=infra/bootstrap init
+```
+
+This downloads the AWS provider and prepares the bootstrap directory. State for the bootstrap itself is stored locally (in `infra/bootstrap/terraform.tfstate`).
+
+### Step 2: Review the Plan
+
+```bash
+tofu -chdir=infra/bootstrap plan \
+  -var='state_bucket_name=emerald-grove-tfstate' \
+  -var='lock_table_name=emerald-grove-tflock'
+```
+
+Verify the plan shows:
+
+- 1 S3 bucket (with versioning + encryption + public access block)
+- 1 DynamoDB table (with `LockID` hash key)
+
+### Step 3: Apply
+
+```bash
+tofu -chdir=infra/bootstrap apply \
+  -var='state_bucket_name=emerald-grove-tfstate' \
+  -var='lock_table_name=emerald-grove-tflock'
+```
+
+Type `yes` when prompted. This creates the state backend resources.
+
+### Step 4: Verify
+
+```bash
+# Confirm S3 bucket exists
+aws s3 ls | grep emerald-grove-tfstate
+
+# Confirm DynamoDB table exists
+aws dynamodb describe-table --table-name emerald-grove-tflock --query 'Table.TableName'
+```
+
+### Step 5: Initialize Main Infrastructure
+
+Now that the state backend exists, initialize the main infrastructure config:
+
+```bash
+tofu -chdir=infra init \
+  -backend-config=bucket=emerald-grove-tfstate \
+  -backend-config=dynamodb_table=emerald-grove-tflock
+```
+
+You can now plan and apply the main infrastructure:
+
+```bash
+# Plan staging
+tofu -chdir=infra plan -var-file=environments/staging.tfvars
+
+# Plan production
+tofu -chdir=infra plan -var-file=environments/prod.tfvars
+```
+
+## Tear Down
+
+To destroy the state backend (only do this if you've already destroyed all managed infrastructure):
+
+```bash
+tofu -chdir=infra/bootstrap destroy \
+  -var='state_bucket_name=emerald-grove-tfstate' \
+  -var='lock_table_name=emerald-grove-tflock'
+```
+
+The S3 bucket must be empty before it can be destroyed. If it contains state files, empty it first:
+
+```bash
+aws s3 rm s3://emerald-grove-tfstate --recursive
+```
+
+## Troubleshooting
+
+### "No valid credential sources found"
+
+AWS CLI is not configured or credentials are expired. Run `aws sts get-caller-identity` to verify.
+
+### "BucketAlreadyExists"
+
+The S3 bucket name is globally unique. If someone else has this name, change `state_bucket_name` to something unique (e.g., add your account ID suffix).
+
+### "Table already exists"
+
+The bootstrap was already run. If you need to re-run, either import the existing resources or destroy first.
+
+### Bootstrap state file
+
+The bootstrap's own state is stored locally at `infra/bootstrap/terraform.tfstate`. This file is gitignored. If you lose it, you can import the existing resources:
+
+```bash
+tofu -chdir=infra/bootstrap import \
+  -var='state_bucket_name=emerald-grove-tfstate' \
+  -var='lock_table_name=emerald-grove-tflock' \
+  aws_s3_bucket.state emerald-grove-tfstate
+
+tofu -chdir=infra/bootstrap import \
+  -var='state_bucket_name=emerald-grove-tfstate' \
+  -var='lock_table_name=emerald-grove-tflock' \
+  aws_dynamodb_table.lock emerald-grove-tflock
+```

--- a/docs/specs/DEVOPS_ROADMAP.md
+++ b/docs/specs/DEVOPS_ROADMAP.md
@@ -46,7 +46,7 @@
 
 ### Spec 13: OpenTofu Foundation
 
-- **Status:** Not started
+- **Status:** Complete (PR #30 merged)
 - **Directory:** `docs/specs/13-spec-opentofu-foundation/`
 - **Scope:** VPC, ECR, ECS Fargate, RDS PostgreSQL, IAM, security groups — staging + prod environments. S3 + DynamoDB state backend. Single module with tfvars per environment.
 - **Depends on:** Spec 11


### PR DESCRIPTION
## Summary
- Added AWS CLI to .mise.toml
- Created docs/BOOTSTRAP.md with comprehensive state backend bootstrap guide
- Updated README with mise shell activation instructions (fish/bash/zsh)
- Added terraform state files to .gitignore
- Bootstrap executed: S3 bucket + DynamoDB table created in us-east-1

## Test plan
- [x] `mise install` installs AWS CLI
- [x] Bootstrap apply created S3 + DynamoDB successfully
- [x] `tofu init` with remote backend succeeds
- [x] `tofu plan` for staging shows 30 resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive AWS/OpenTofu bootstrap setup guide with prerequisites, verification steps, backend resource creation, and teardown instructions
  * Enhanced setup documentation with AWS CLI installation requirements and Mise shell activation commands for multiple shells
  * Added references to infrastructure configuration guides

* **Chores**
  * Updated project configuration to exclude Terraform state files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->